### PR TITLE
Fix documents table metadata column error

### DIFF
--- a/backend/app/services/email/email_service.py
+++ b/backend/app/services/email/email_service.py
@@ -387,8 +387,8 @@ class EmailProcessingService:
                 ).isoformat(),
                 'created_by': user_id,
                 'summary': content.get('full_content', content.get('body_text', '')), # Use full_content for summary
-                'mimetype': gmail_message.payload.mime_type or None,
-                'metadata': metadata # Store all metadata
+                'mimetype': gmail_message.payload.mime_type or None
+                # Note: metadata field removed as it doesn't exist in documents table schema
             }).execute()
             
             if not result.data:
@@ -410,7 +410,10 @@ class EmailProcessingService:
             result = supabase.table('documents').select('*').eq('id', document_id).execute()
             
             if result.data:
-                return DocumentCreate(**result.data[0])
+                doc_data = result.data[0]
+                # Add default metadata since documents table doesn't have metadata column
+                doc_data['metadata'] = {}
+                return DocumentCreate(**doc_data)
             
             return None
             


### PR DESCRIPTION
- Remove 'metadata' field from documents table insert (column doesn't exist in schema)
- Add default empty metadata when creating DocumentCreate from database result
- Fix 'Could not find the metadata column of documents in the schema cache' error
- Align code with actual database schema which has transcript_metadata but not metadata column