### PR TITLE
Fix DocumentCreate content field validation error

### DIFF
--- a/backend/app/services/email/email_service.py
+++ b/backend/app/services/email/email_service.py
@@ -414,6 +414,8 @@ class EmailProcessingService:
                 doc_data = result.data[0]
                 # Add default metadata since documents table doesn't have metadata column
                 doc_data['metadata'] = {}
+                # Add default content since documents table doesn't have content column
+                doc_data['content'] = doc_data.get('summary', '')
                 return DocumentCreate(**doc_data)
             
             return None


### PR DESCRIPTION
- Add default content field when creating DocumentCreate from database result
- Use summary field as content since documents table doesn't have content column
- Fix 'Field required [type=missing, input_value=..., input_type=dict]' validation error
- Ensure DocumentCreate model gets all required fields from database data