### PR TITLE
Fix DocumentCreate missing received_at attribute error

### DIFF
--- a/backend/app/models/schemas/email.py
+++ b/backend/app/models/schemas/email.py
@@ -133,6 +133,7 @@ class DocumentCreate(BaseModel):
     source: str = Field("email", description="Document source")
     source_id: str = Field(..., description="Source ID (Gmail message ID)")
     author: Optional[str] = Field(None, description="Document author")
+    received_at: Optional[str] = Field(None, description="Document received timestamp")
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Document metadata")
 
 


### PR DESCRIPTION
- Add received_at field to DocumentCreate model
- Fix 'DocumentCreate' object has no attribute 'received_at' error
- Ensure DocumentCreate model includes all fields from documents table
- Allow received_at to be accessed in classification payload building