### PR TITLE
Fix OpenAI API, database schema, and RLS policy errors

### DIFF
--- a/backend/app/services/ai/classification_service.py
+++ b/backend/app/services/ai/classification_service.py
@@ -521,7 +521,7 @@ Please analyze the content and return ONLY a valid JSON response following the e
             
             # Make the OpenAI API call
             response = await self.openai_client.chat.completions.create(
-                model="gpt-4",
+                model="gpt-4o",  # Use gpt-4o which supports response_format
                 messages=[
                     {"role": "system", "content": self.classification_prompt},
                     {"role": "user", "content": user_message}
@@ -667,16 +667,16 @@ Please analyze the content and return ONLY a valid JSON response following the e
             # Update documents table
             if content.get('source_id'):
                 self.supabase.table('documents').update({
-                    'project_id': project_id,
-                    'updated_at': datetime.now().isoformat()
+                    'project_id': project_id
+                    # 'updated_at': datetime.now().isoformat()  # Column doesn't exist in schema
                 }).eq('id', content['source_id']).execute()
                 logger.info(f"Updated document {content['source_id']} with project_id {project_id}")
             
             # Update email_processing_logs if applicable
             if content.get('type') == 'email':
                 self.supabase.table('email_processing_logs').update({
-                    'project_id': project_id,
-                    'updated_at': datetime.now().isoformat()
+                    'project_id': project_id
+                    # 'updated_at': datetime.now().isoformat()  # Column doesn't exist in schema
                 }).eq('document_id', content.get('source_id')).execute()
             
         except Exception as e:

--- a/backend/app/services/email/email_service.py
+++ b/backend/app/services/email/email_service.py
@@ -373,7 +373,7 @@ class EmailProcessingService:
     ) -> str:
         """Create a document record from email."""
         try:
-            supabase = get_supabase()
+            supabase = get_supabase_service_client()  # Use service role client to bypass RLS
             if not supabase:
                 raise Exception("Supabase client not available")
             


### PR DESCRIPTION
- Change OpenAI model from gpt-4 to gpt-4o to support response_format json_object
- Remove updated_at field from document updates (column doesn't exist in schema)
- Use service role client in _create_document_from_email to bypass RLS policies
- Fix 'response_format json_object not supported' OpenAI API error
- Fix 'Could not find updated_at column' database schema error
- Fix 'new row violates row-level security policy' RLS violation error
- Ensure proper database access for document creation and updates