### PR TITLE
Fix project_id column and JSON serialization errors

### DIFF
--- a/backend/app/services/ai/classification_service.py
+++ b/backend/app/services/ai/classification_service.py
@@ -674,10 +674,11 @@ Please analyze the content and return ONLY a valid JSON response following the e
             
             # Update email_processing_logs if applicable
             if content.get('type') == 'email':
-                self.supabase.table('email_processing_logs').update({
-                    'project_id': project_id
-                    # 'updated_at': datetime.now().isoformat()  # Column doesn't exist in schema
-                }).eq('document_id', content.get('source_id')).execute()
+                # Note: project_id column doesn't exist in email_processing_logs schema
+                # self.supabase.table('email_processing_logs').update({
+                #     'project_id': project_id
+                # }).eq('document_id', content.get('source_id')).execute()
+                logger.info(f"Skipping email_processing_logs update - project_id column doesn't exist in schema")
             
         except Exception as e:
             logger.error(f"Error updating document project: {e}")


### PR DESCRIPTION
- Remove project_id update from email_processing_logs (column doesn't exist in schema)
- Fix SyncRPCFilterRequestBuilder JSON serialization error in project tracking
- Execute RPC call first to get actual result before using in update
- Use service role client for project classification tracking to bypass RLS
- Fix 'Could not find project_id column of email_processing_logs' error
- Fix 'Object of type SyncRPCFilterRequestBuilder is not JSON serializable' error