### PR TITLE
Add GET endpoint fallback for RAG agent queries

### DIFF
--- a/backend/app/api/v1/rag_agent.py
+++ b/backend/app/api/v1/rag_agent.py
@@ -83,6 +83,21 @@ async def get_project_summary(
         logger.error(f"Error getting project summary: {e}")
         raise HTTPException(status_code=500, detail="Failed to get project summary")
 
+@router.get("/query")
+async def query_project_data_get(
+    question: str,
+    project_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user)
+):
+    """GET endpoint for RAG agent queries (fallback for debugging)."""
+    try:
+        # Convert GET parameters to POST request format
+        request = RAGQueryRequest(question=question, project_id=project_id)
+        return await query_project_data(request, current_user)
+    except Exception as e:
+        logger.error(f"Error in RAG GET query: {e}")
+        raise HTTPException(status_code=500, detail="Failed to process RAG query")
+
 @router.get("/health")
 async def rag_agent_health():
     """Health check for the RAG agent service."""


### PR DESCRIPTION
- Add GET /query endpoint as fallback for debugging 405 errors
- Convert GET parameters to POST request format internally
- Help diagnose if frontend is making GET instead of POST requests
- Maintain backward compatibility with existing POST endpoint
- Fix potential 405 Method Not Allowed errors from frontend