### PR TITLE
Add read_then_archive option for Gmail email processing

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,7 +87,7 @@ class Settings(BaseSettings):
     verify_gmail_webhooks: bool = Field(default=True, env="VERIFY_GMAIL_WEBHOOKS")
     
     # Gmail email processing
-    gmail_mark_processed_action: str = Field(default="read", env="GMAIL_MARK_PROCESSED_ACTION")  # "read" or "archive"
+    gmail_mark_processed_action: str = Field(default="read_then_archive", env="GMAIL_MARK_PROCESSED_ACTION")  # "read", "archive", or "read_then_archive"
     
     # Attendee service settings
     attendee_api_base_url: Optional[str] = Field(default=None, env="ATTENDEE_API_BASE_URL")

--- a/backend/app/services/email/gmail_service.py
+++ b/backend/app/services/email/gmail_service.py
@@ -265,12 +265,22 @@ class GmailService:
             return False
     
     async def mark_email_as_processed(self, message_id: str, action: str = "read") -> bool:
-        """Mark an email as processed by either reading or archiving it."""
+        """Mark an email as processed by either reading, archiving, or both."""
         try:
             if action == "read":
                 return await self.mark_email_as_read(message_id)
             elif action == "archive":
                 return await self.archive_email(message_id)
+            elif action == "read_then_archive":
+                # First mark as read
+                read_success = await self.mark_email_as_read(message_id)
+                if read_success:
+                    # Then archive it
+                    archive_success = await self.archive_email(message_id)
+                    return archive_success
+                else:
+                    logger.warning(f"Failed to mark email {message_id} as read, skipping archive")
+                    return False
             else:
                 logger.warning(f"Unknown action '{action}', defaulting to 'read'")
                 return await self.mark_email_as_read(message_id)


### PR DESCRIPTION
- Add read_then_archive action to mark_email_as_processed method
- First marks email as read, then archives it in sequence
- Update default GMAIL_MARK_PROCESSED_ACTION to read_then_archive
- Support three actions: read, archive, read_then_archive
- Ensure proper error handling if read step fails before archive
- Provide more granular control over email status management