### PR TITLE
Fix RAG agent content retrieval from Pinecone

### DIFF
--- a/backend/app/services/ai/rag_agent_service.py
+++ b/backend/app/services/ai/rag_agent_service.py
@@ -261,12 +261,17 @@ Please provide a helpful, accurate response based on the retrieved context."""
             )
             
             context_items = []
-            for match in search_results.matches:
+            logger.info(f"Pinecone search returned {len(search_results.matches)} matches for query: {query[:100]}...")
+            
+            for i, match in enumerate(search_results.matches):
+                chunk_text = match.metadata.get('chunk_text', '')
+                logger.info(f"Match {i+1} - Score: {match.score:.3f}, Content length: {len(chunk_text)}, Preview: {chunk_text[:200]}...")
+                
                 context_items.append({
                     'type': 'vector_chunk',
                     'source': match.metadata.get('content_type', 'unknown'),
                     'title': match.metadata.get('subject', 'Vector Chunk'),
-                    'content': match.metadata.get('chunk_text', ''),
+                    'content': chunk_text,
                     'author': match.metadata.get('author', 'Unknown'),
                     'created_at': match.metadata.get('embedded_at', ''),
                     'metadata': {
@@ -279,6 +284,7 @@ Please provide a helpful, accurate response based on the retrieved context."""
                     }
                 })
             
+            logger.info(f"Returning {len(context_items)} context items from Pinecone")
             return context_items
             
         except Exception as e:

--- a/backend/app/services/ai/vector_embedding_service.py
+++ b/backend/app/services/ai/vector_embedding_service.py
@@ -141,6 +141,7 @@ class VectorEmbeddingService:
                         'author': content.get('author', ''),
                         'date': content.get('date', ''),
                         'subject': content.get('subject', ''),
+                        'chunk_text': chunks[i]['text'],  # Add the actual chunk text content
                         'confidence': classification_result.get('confidence', 0.0),
                         'matched_tags': classification_result.get('document', {}).get('matched_tags', []),
                         'inferred_tags': classification_result.get('document', {}).get('inferred_tags', []),
@@ -191,6 +192,11 @@ class VectorEmbeddingService:
             # Store embeddings in Pinecone
             self.index.upsert(vectors=embeddings)
             logger.info(f"Successfully stored {len(embeddings)} embeddings in Pinecone")
+            
+            # Debug: Log what content was embedded
+            for i, emb in enumerate(embeddings):
+                chunk_text = emb['metadata'].get('chunk_text', '')
+                logger.info(f"Embedded chunk {i+1}/{len(embeddings)} - Length: {len(chunk_text)}, Preview: {chunk_text[:200]}...")
             
             # Log embedding activity
             await self._log_embedding_activity(content, classification_result, user_id, len(embeddings))


### PR DESCRIPTION
- Add missing chunk_text field to Pinecone metadata storage
- Add debug logging to vector embedding service to show what content is embedded
- Add debug logging to RAG agent to show what content is retrieved
- This fixes the issue where RAG agent couldn't find email content because chunk_text was missing from metadata