### PR TITLE
Replace logger.info with print statements for debug logging

### DIFF
--- a/backend/app/services/ai/rag_agent_service.py
+++ b/backend/app/services/ai/rag_agent_service.py
@@ -261,11 +261,18 @@ Please provide a helpful, accurate response based on the retrieved context."""
             )
             
             context_items = []
-            logger.info(f"Pinecone search returned {len(search_results.matches)} matches for query: {query[:100]}...")
+            print(f"=== PINECONE SEARCH RESULTS ===")
+            print(f"Query: {query[:100]}...")
+            print(f"Matches found: {len(search_results.matches)}")
             
             for i, match in enumerate(search_results.matches):
                 chunk_text = match.metadata.get('chunk_text', '')
-                logger.info(f"Match {i+1} - Score: {match.score:.3f}, Content length: {len(chunk_text)}, Preview: {chunk_text[:200]}...")
+                print(f"--- MATCH {i+1} ---")
+                print(f"Score: {match.score:.3f}")
+                print(f"Content length: {len(chunk_text)}")
+                print(f"Preview: {chunk_text[:200]}...")
+                print(f"Full content: {chunk_text}")
+                print("-" * 30)
                 
                 context_items.append({
                     'type': 'vector_chunk',
@@ -284,7 +291,8 @@ Please provide a helpful, accurate response based on the retrieved context."""
                     }
                 })
             
-            logger.info(f"Returning {len(context_items)} context items from Pinecone")
+            print(f"Returning {len(context_items)} context items from Pinecone")
+            print("=" * 50)
             return context_items
             
         except Exception as e:

--- a/backend/app/services/ai/vector_embedding_service.py
+++ b/backend/app/services/ai/vector_embedding_service.py
@@ -196,7 +196,11 @@ class VectorEmbeddingService:
             # Debug: Log what content was embedded
             for i, emb in enumerate(embeddings):
                 chunk_text = emb['metadata'].get('chunk_text', '')
-                logger.info(f"Embedded chunk {i+1}/{len(embeddings)} - Length: {len(chunk_text)}, Preview: {chunk_text[:200]}...")
+                print(f"=== EMBEDDED CHUNK {i+1}/{len(embeddings)} ===")
+                print(f"Length: {len(chunk_text)}")
+                print(f"Preview: {chunk_text[:200]}...")
+                print(f"Full content: {chunk_text}")
+                print("=" * 50)
             
             # Log embedding activity
             await self._log_embedding_activity(content, classification_result, user_id, len(embeddings))

--- a/backend/app/services/email/email_service.py
+++ b/backend/app/services/email/email_service.py
@@ -275,7 +275,13 @@ class EmailProcessingService:
             content['full_content'] = '\n\n'.join(full_content_parts)
             
             # Log content extraction details
-            logger.info(f"Email content extracted - Body text length: {len(content['body_text'])}, HTML length: {len(content['body_html'])}, Full content length: {len(content['full_content'])}, Preview: {content['full_content'][:200]}...")
+            print(f"=== EMAIL CONTENT EXTRACTED ===")
+            print(f"Body text length: {len(content['body_text'])}")
+            print(f"HTML length: {len(content['body_html'])}")
+            print(f"Full content length: {len(content['full_content'])}")
+            print(f"Preview: {content['full_content'][:200]}...")
+            print(f"Full content: {content['full_content']}")
+            print("=" * 50)
             
             return content
             


### PR DESCRIPTION
- Use print() statements instead of logger.info() for debug output
- Add detailed print statements for email content extraction
- Add detailed print statements for vector embedding process
- Add detailed print statements for RAG agent retrieval
- This ensures debug output appears in Railway logs for troubleshooting