### PR TITLE
Add debug logging to show raw payload structure

### DIFF
--- a/backend/app/api/v1/webhooks/gmail_webhook.py
+++ b/backend/app/api/v1/webhooks/gmail_webhook.py
@@ -500,6 +500,13 @@ def _convert_to_gmail_message(raw_message: Dict[str, Any]) -> Optional[Any]:
         
         # Extract payload
         raw_payload = raw_message.get('payload', {})
+        print(f"Raw payload keys: {list(raw_payload.keys())}")
+        print(f"Raw payload mimeType: {raw_payload.get('mimeType')}")
+        print(f"Raw payload has parts: {bool(raw_payload.get('parts'))}")
+        if raw_payload.get('parts'):
+            print(f"Raw payload parts count: {len(raw_payload['parts'])}")
+        else:
+            print("No parts in raw payload")
         
         # Convert headers
         headers = []


### PR DESCRIPTION
- Add debug logging to show raw payload keys and mimeType
- Add debug logging to show if parts exist in raw payload
- This will help identify why parts conversion is not being called
- Should reveal if the raw Gmail API response has parts or not