### PR TITLE
Fix JWT token verification for Supabase tokens with audience claims

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,7 @@ redis>=5.0.1
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 bcrypt>=4.1.2
+PyJWT>=2.8.0
 
 # Google OAuth and API libraries
 google-auth>=2.23.0


### PR DESCRIPTION
- Add verify_supabase_token method to handle Supabase JWT tokens properly
- Update get_current_user_hybrid to try Supabase JWT verification first
- Add PyJWT dependency for Supabase JWT verification
- Fix 'Invalid audience' error when deploying bots