### PR TITLE
Fix import path in transcript service

### DIFF
--- a/backend/app/services/attendee/transcript_service.py
+++ b/backend/app/services/attendee/transcript_service.py
@@ -6,7 +6,7 @@ Handles transcript retrieval and storage in the meeting_bots table.
 import logging
 import httpx
 from typing import Optional, Dict, Any
-from ..core.config import get_settings
+from ...core.config import get_settings
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Correct import path from ..core.config to ...core.config
- Fixes ModuleNotFoundError: No module named 'app.services.core'
- Resolves deployment crash due to incorrect relative import