### PR TITLE
Fix BotSyncService async/sync method mismatch

### DIFF
--- a/backend/app/api/v1/bot_sync.py
+++ b/backend/app/api/v1/bot_sync.py
@@ -21,7 +21,7 @@ async def sync_bot_status(
     """Sync bot status from meeting_bots table to meetings table."""
     try:
         bot_sync_service = BotSyncService()
-        result = await bot_sync_service.sync_bot_status_to_meetings(current_user["id"])
+        result = bot_sync_service.sync_bot_status_to_meetings(current_user["id"])
         
         return {
             "success": True,
@@ -46,7 +46,7 @@ async def get_meetings_with_bot_status(
         logger.info(f"API endpoint called with user_id: {user_id}, unassigned_only: {unassigned_only}, future_only: {future_only}")
         
         bot_sync_service = BotSyncService()
-        meetings = await bot_sync_service.get_user_meetings_with_bot_status(
+        meetings = bot_sync_service.get_user_meetings_with_bot_status(
             user_id, 
             unassigned_only=unassigned_only, 
             future_only=future_only
@@ -73,7 +73,7 @@ async def get_meeting_with_bot_status(
     """Get a specific meeting with its associated bot status."""
     try:
         bot_sync_service = BotSyncService()
-        meeting = await bot_sync_service.get_meeting_with_bot_status(meeting_id, current_user["id"])
+        meeting = bot_sync_service.get_meeting_with_bot_status(meeting_id, current_user["id"])
         
         if not meeting:
             raise HTTPException(status_code=404, detail="Meeting not found")

--- a/backend/app/services/attendee/bot_sync_service.py
+++ b/backend/app/services/attendee/bot_sync_service.py
@@ -18,7 +18,7 @@ class BotSyncService:
     def __init__(self):
         self.supabase = get_supabase()
     
-    async def sync_bot_status_to_meetings(self, user_id: str) -> Dict[str, Any]:
+    def sync_bot_status_to_meetings(self, user_id: str) -> Dict[str, Any]:
         """
         Sync bot status from meeting_bots table to meetings table.
         Now uses the foreign key relationship instead of URL lookups.
@@ -89,7 +89,7 @@ class BotSyncService:
             logger.error(f"Failed to sync bot status: {e}")
             return {"success": False, "error": str(e)}
     
-    async def get_meeting_with_bot_status(self, meeting_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+    def get_meeting_with_bot_status(self, meeting_id: str, user_id: str) -> Optional[Dict[str, Any]]:
         """
         Get a meeting with its associated bot status using foreign key relationship.
         """
@@ -148,7 +148,7 @@ class BotSyncService:
             logger.error(f"Failed to get meeting with bot status: {e}")
             return None
     
-    async def get_user_meetings_with_bot_status(self, user_id: str, unassigned_only: bool = True, future_only: bool = True) -> List[Dict[str, Any]]:
+    def get_user_meetings_with_bot_status(self, user_id: str, unassigned_only: bool = True, future_only: bool = True) -> List[Dict[str, Any]]:
         """
         Get meetings for a user with their associated bot status using JOIN query.
         """


### PR DESCRIPTION
- Remove async from methods that use synchronous Supabase calls
- Fix sync_bot_status_to_meetings, get_meeting_with_bot_status, get_user_meetings_with_bot_status
- Remove await calls in API endpoints for these methods
- Resolves 'SyncSelectRequestBuilder' object is not callable error
- Fixes bot sync service startup failures