### PR TITLE
Remove desc=True parameter to debug SyncSelectRequestBuilder error

### DIFF
--- a/backend/app/services/attendee/bot_sync_service.py
+++ b/backend/app/services/attendee/bot_sync_service.py
@@ -171,7 +171,7 @@ class BotSyncService:
                 logger.info(f"Applied future filter from {now}")
             
             # Order by start_time descending
-            meetings_result = query.order('start_time', desc=True).execute()
+            meetings_result = query.order('start_time').execute()
             
             logger.info(f"Backend query returned {len(meetings_result.data) if meetings_result.data else 0} meetings")
             


### PR DESCRIPTION
- Remove desc=True from order() method call
- Test if this fixes the 'SyncSelectRequestBuilder' object is not callable error
- This will help isolate if the issue is with the desc parameter