### PR TITLE
Fix async/await syntax error in vector_embedding_service.py

### DIFF
--- a/backend/app/services/ai/vector_embedding_service.py
+++ b/backend/app/services/ai/vector_embedding_service.py
@@ -122,7 +122,7 @@ class VectorEmbeddingService:
                 }
             
             # Create content chunks
-            chunks = self._create_content_chunks(content)
+            chunks = await self._create_content_chunks(content)
             logger.info(f"Created {len(chunks)} chunks for content: {content.get('source_id', 'unknown')}")
             
             # Generate embeddings for each chunk
@@ -273,7 +273,7 @@ class VectorEmbeddingService:
             logger.error(f"Error deleting document vectors: {e}")
             return False
     
-    def _create_content_chunks(self, content: Dict[str, Any]) -> List[Dict[str, Any]]:
+    async def _create_content_chunks(self, content: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Create optimized text chunks from content for embedding."""
         try:
             # Get the best available content


### PR DESCRIPTION
- Made _create_content_chunks method async to properly await semantic_chunker.create_semantic_chunks()
- Updated call to _create_content_chunks in embed_classified_content to use await
- This fixes the SyntaxError: 'await' outside async function error