### PR TITLE
Increase context content length limit to preserve team member informa…

### DIFF
--- a/backend/app/services/ai/rag_agent_service.py
+++ b/backend/app/services/ai/rag_agent_service.py
@@ -751,8 +751,8 @@ Provide a helpful, accurate response grounded in the project database."""
             for i, item in enumerate(context, 1):
                 source_type = item.get('source', 'unknown').replace('_', ' ').title()
                 title = item.get('title', 'Untitled')
-                # Increase content length limit to 1000 characters to preserve more context
-                content = item.get('content', '')[:1000] + "..." if len(item.get('content', '')) > 1000 else item.get('content', '')
+                # Increase content length limit to 3000 characters to preserve more context including team member info
+                content = item.get('content', '')[:3000] + "..." if len(item.get('content', '')) > 3000 else item.get('content', '')
                 author = item.get('author', 'Unknown')
                 date = item.get('created_at', 'Unknown')
                 relevance = item.get('relevance_score', 0)


### PR DESCRIPTION
…tion

- Increase content length limit from 1000 to 3000 characters in context formatting
- This should allow the full email content including team member details to be sent to the AI model
- Team member information was being truncated in the previous 1000 character limit